### PR TITLE
Update Camomile module paths for 2.0.0

### DIFF
--- a/src/charInfo_width.ml
+++ b/src/charInfo_width.ml
@@ -1,4 +1,4 @@
-open CamomileLibraryDefault.Camomile
+open Camomile
 open Result
 
 module Cfg = Cfg

--- a/src/charInfo_width.mli
+++ b/src/charInfo_width.mli
@@ -1,4 +1,4 @@
-open CamomileLibraryDefault.Camomile
+open Camomile
 open Result
 
 module Cfg = Cfg

--- a/src/codes.ml
+++ b/src/codes.ml
@@ -1,4 +1,4 @@
-open CamomileLibraryDefault.Camomile
+open Camomile
 
 include USet
 

--- a/src/codes.mli
+++ b/src/codes.mli
@@ -1,4 +1,4 @@
-(** [Codes] expands some functions based on CamomileLibrary.USet,
+(** [Codes] expands some functions based on Camomile.USet,
     a module implements Sets of Unicode characters, implemented as sets of intervals.
 *)
 
@@ -9,27 +9,27 @@ type t
 
 (** based on add_range, [add_ranges l s] add a list of ranges [l] to [s]. *)
 val add_ranges :
-  (CamomileLibrary.UChar.t * CamomileLibrary.UChar.t) list -> t -> t
+  (Camomile.UChar.t * Camomile.UChar.t) list -> t -> t
 
 (** [tuple_to_range tuple] convert [tuple] to a UChar range *)
 val tuple_to_range :
-  int * int -> CamomileLibrary.UChar.t * CamomileLibrary.UChar.t
+  int * int -> Camomile.UChar.t * Camomile.UChar.t
 
 (** [of_tuple_list l] convert int tuple list [l] to a [USet.t] *)
 val of_tuple_list : (int * int) list -> t
 
-(** {3 Below are type signatures of the original [CamomileLibrary.USet] module} *)
+(** {3 Below are type signatures of the original [Camomile.USet] module} *)
 
 val empty : t
 val is_empty : t -> bool
-val mem : CamomileLibrary.UChar.t -> t -> bool
-val add : CamomileLibrary.UChar.t -> t -> t
+val mem : Camomile.UChar.t -> t -> bool
+val add : Camomile.UChar.t -> t -> t
 val add_range :
-  CamomileLibrary.UChar.t -> CamomileLibrary.UChar.t -> t -> t
-val singleton : CamomileLibrary.UChar.t -> t
-val remove : CamomileLibrary.UChar.t -> t -> t
+  Camomile.UChar.t -> Camomile.UChar.t -> t -> t
+val singleton : Camomile.UChar.t -> t
+val remove : Camomile.UChar.t -> t -> t
 val remove_range :
-  CamomileLibrary.UChar.t -> CamomileLibrary.UChar.t -> t -> t
+  Camomile.UChar.t -> Camomile.UChar.t -> t -> t
 val union : t -> t -> t
 val inter : t -> t -> t
 val diff : t -> t -> t
@@ -37,27 +37,27 @@ val compl : t -> t
 val compare : t -> t -> int
 val equal : t -> t -> bool
 val subset : t -> t -> bool
-val from : CamomileLibrary.UChar.t -> t -> t
-val after : CamomileLibrary.UChar.t -> t -> t
-val until : CamomileLibrary.UChar.t -> t -> t
-val before : CamomileLibrary.UChar.t -> t -> t
-val iter : (CamomileLibrary.UChar.t -> unit) -> t -> unit
+val from : Camomile.UChar.t -> t -> t
+val after : Camomile.UChar.t -> t -> t
+val until : Camomile.UChar.t -> t -> t
+val before : Camomile.UChar.t -> t -> t
+val iter : (Camomile.UChar.t -> unit) -> t -> unit
 val iter_range :
-  (CamomileLibrary.UChar.t -> CamomileLibrary.UChar.t -> unit) -> t -> unit
-val fold : (CamomileLibrary.UChar.t -> 'a -> 'a) -> t -> 'a -> 'a
+  (Camomile.UChar.t -> Camomile.UChar.t -> unit) -> t -> unit
+val fold : (Camomile.UChar.t -> 'a -> 'a) -> t -> 'a -> 'a
 val fold_range :
-  (CamomileLibrary.UChar.t -> CamomileLibrary.UChar.t -> 'a -> 'a) ->
+  (Camomile.UChar.t -> Camomile.UChar.t -> 'a -> 'a) ->
   t -> 'a -> 'a
-val for_all : (CamomileLibrary.UChar.t -> bool) -> t -> bool
-val exists : (CamomileLibrary.UChar.t -> bool) -> t -> bool
-val filter : (CamomileLibrary.UChar.t -> bool) -> t -> t
-val partition : (CamomileLibrary.UChar.t -> bool) -> t -> t * t
+val for_all : (Camomile.UChar.t -> bool) -> t -> bool
+val exists : (Camomile.UChar.t -> bool) -> t -> bool
+val filter : (Camomile.UChar.t -> bool) -> t -> t
+val partition : (Camomile.UChar.t -> bool) -> t -> t * t
 val cardinal : t -> int
-val elements : t -> CamomileLibrary.UChar.t list
-val ranges : t -> (CamomileLibrary.UChar.t * CamomileLibrary.UChar.t) list
-val min_elt : t -> CamomileLibrary.UChar.t
-val max_elt : t -> CamomileLibrary.UChar.t
-val choose : t -> CamomileLibrary.UChar.t
-val uset_of_iset : CamomileLibrary.Private.ISet.t -> t
-val iset_of_uset : t -> CamomileLibrary.Private.ISet.t
+val elements : t -> Camomile.UChar.t list
+val ranges : t -> (Camomile.UChar.t * Camomile.UChar.t) list
+val min_elt : t -> Camomile.UChar.t
+val max_elt : t -> Camomile.UChar.t
+val choose : t -> Camomile.UChar.t
+val uset_of_iset : Camomile.Private.ISet.t -> t
+val iset_of_uset : t -> Camomile.Private.ISet.t
 


### PR DESCRIPTION
Camomile 2.0.0 changed the module path, so old code no longer builds with it.

I might have wanted them to go through a deprecation period, or make a compatibility package, or do something else less radical, but at least it's a very simple change.